### PR TITLE
fix(deploy): resolve CORS, SignalR 405, and SWA route errors

### DIFF
--- a/.agent/rules/moderngoldenrules.md
+++ b/.agent/rules/moderngoldenrules.md
@@ -4,7 +4,7 @@ trigger: always_on
 
 # Rules Brain: Modern Golden Rules (Master Authority)
 
-**Version**: 1.8.0 | **Last Updated**: 2026-02-26 | **Standards**: 34 (6 categories)
+**Version**: 1.9.0 | **Last Updated**: 2026-02-26 | **Standards**: 35 (6 categories)
 
 You are an expert agent co-developing this system. You MUST follow these rules unconditionally. This document is your **Executive Directive**.
 
@@ -238,7 +238,7 @@ You MUST load and apply the relevant standard based on task type.
 | Soft Delete | [soft-delete-standard.md](standards/soft-delete-standard.md) |
 | GDPR & PII | [gdpr-pii-standard.md](standards/gdpr-pii-standard.md) |
 
-### Category 4: Integration & Infrastructure (5 standards)
+### Category 4: Integration & Infrastructure (6 standards)
 | Pattern | Standard |
 |---------|----------|
 | SAP Integration | [sap-integration-standard.md](standards/sap-integration-standard.md) |
@@ -246,6 +246,7 @@ You MUST load and apply the relevant standard based on task type.
 | Email Service | [email-service-standard.md](standards/email-service-standard.md) |
 | Multi-Tenancy | [multi-tenancy-standard.md](standards/multi-tenancy-standard.md) |
 | Data Residency | [data-residency-standard.md](standards/data-residency-standard.md) |
+| Deployment Environment | [deployment-environment-standard.md](standards/deployment-environment-standard.md) |
 
 ### Category 5: Operations & Quality (7 standards)
 | Pattern | Standard |
@@ -306,6 +307,10 @@ What are you implementing?
 │
 ├─► Testing?
 │   └─► Read: testing-standard.md
+│
+├─► Deployment / CORS / SignalR / environment issue?
+│   ├─► Read: deployment-environment-standard.md
+│   └─► Read: cicd-setup-standards.md
 │
 └─► Not sure?
     └─► Start with: hexagonal-architecture-standards.md

--- a/.agent/rules/standards/cicd-setup-standards.md
+++ b/.agent/rules/standards/cicd-setup-standards.md
@@ -339,6 +339,26 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ---
 
+## 8. Environment Alignment (MANDATORY)
+
+**CRITICAL**: Every deployment MUST maintain alignment between frontend origins, backend CORS, and environment variables. See [deployment-environment-standard.md](deployment-environment-standard.md) for the full standard.
+
+### Key Rules
+
+1. **ASPNETCORE_ENVIRONMENT**: Must be set explicitly in every App Service deployment via `azure/appservice-settings@v1` (never rely on Azure defaults)
+2. **CORS Origins**: The Origin Registry in [deployment-environment-standard.md](deployment-environment-standard.md) is the source of truth. Every SWA URL MUST be in the backend CORS config.
+3. **Frontend Env Vars**: `.env.production` MUST set both `VITE_API_BASE_URL` (with `/api`) and `VITE_API_URL` (without `/api`)
+4. **Post-Deployment Verification**: Every backend deployment MUST include CORS preflight + SignalR negotiate checks
+
+### When Adding New Environments
+
+1. Update Origin Registry in `deployment-environment-standard.md`
+2. Add CORS origin in `Program.cs` → `GetAllowedOrigins()`
+3. Add App Settings step in `deploy-backend-api.yml`
+4. Create/update `.env.[environment]` in frontend
+
+---
+
 ## Next Steps
 
 1. ✅ Add all required secrets to GitHub
@@ -349,4 +369,4 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ---
 
-**All workflows created! Ready for automated deployments.** 🚀
+**All workflows created! Ready for automated deployments.**

--- a/.agent/rules/standards/deployment-environment-standard.md
+++ b/.agent/rules/standards/deployment-environment-standard.md
@@ -1,0 +1,189 @@
+# Deployment Environment Alignment Standard
+
+**Category**: Integration & Infrastructure
+**Pattern #**: 35
+**Status**: MANDATORY
+**Priority**: 🔴 CRITICAL
+
+---
+
+## Definition
+
+All deployed environments MUST have explicit, verified alignment between frontend origin URLs, backend CORS configuration, environment variables, and ASP.NET Core environment settings. A mismatch in any of these causes silent runtime failures (CORS blocks, SignalR 405, auth failures) that are invisible to build/test CI.
+
+---
+
+## Rules
+
+1. **ALWAYS** set `ASPNETCORE_ENVIRONMENT` explicitly in every Azure App Service deployment (never rely on defaults)
+2. **ALWAYS** include the actual SWA origin URL in the backend CORS allowed origins for the matching environment
+3. **ALWAYS** ensure frontend env vars (`VITE_API_BASE_URL`, `VITE_API_URL`) are consistent and both point to the same backend
+4. **NEVER** use relative API paths (`/api`, `/hubs`) in production builds when frontend and backend are on different origins
+5. **NEVER** add SWA route rules for `/api/*` when using an external backend (SWA managed APIs only)
+6. **ALWAYS** run CORS preflight + SignalR negotiate verification as post-deployment CI steps
+7. **ALWAYS** keep the Origin Registry (below) updated when SWA or App Service URLs change
+
+---
+
+## Origin Registry (Source of Truth)
+
+| Environment | Frontend (SWA) | Backend (App Service) | ASPNETCORE_ENVIRONMENT |
+|-------------|----------------|-----------------------|------------------------|
+| **Development** | `https://thankful-field-0258f8110.3.azurestaticapps.net` | `https://app-vendor-mdm-api-dev.azurewebsites.net` | `Development` |
+| **Staging** | `https://purple-moss-066604e03.4.azurestaticapps.net` | TBD | `Staging` |
+| **Production** | `https://victorious-water-095da360f.5.azurestaticapps.net` | `https://app-vendor-mdm-api-prod.azurewebsites.net` | `Production` |
+| **Local** | `http://localhost:3000` | `http://localhost:5001` | `Development` |
+
+---
+
+## Implementation
+
+### 1. Backend CORS Must Match Origin Registry
+
+```csharp
+// Program.cs - GetAllowedOrigins()
+// EVERY SWA URL in the Origin Registry MUST appear in the matching environment block
+// Example: Development environment
+return new[]
+{
+    "http://localhost:3000",
+    "https://thankful-field-0258f8110.3.azurestaticapps.net",  // MUST match registry
+    // ...
+};
+```
+
+### 2. Frontend Environment Variables Must Be Consistent
+
+```bash
+# .env.production - BOTH variables MUST point to same backend
+VITE_API_BASE_URL=https://app-vendor-mdm-api-dev.azurewebsites.net/api    # With /api suffix
+VITE_API_URL=https://app-vendor-mdm-api-dev.azurewebsites.net              # Without /api suffix
+```
+
+**Why two variables?**
+- `VITE_API_BASE_URL` = Used by `api.ts` (axios baseURL, includes `/api`)
+- `VITE_API_URL` = Used by `SignalRContext.tsx` (hub URL base, no `/api` because hub path is `/hubs/events`)
+
+### 3. CI/CD Must Set Environment Explicitly
+
+```yaml
+# deploy-backend-api.yml - Dev deployment
+- name: Configure App Settings (Dev)
+  uses: azure/appservice-settings@v1
+  with:
+    app-name: app-vendor-mdm-api-dev
+    app-settings-json: |
+      [
+        { "name": "ASPNETCORE_ENVIRONMENT", "value": "Development" },
+        { "name": "App__BaseUrl", "value": "https://thankful-field-0258f8110.3.azurestaticapps.net" }
+      ]
+```
+
+### 4. SWA Config Must Not Intercept External API Routes
+
+```json
+// staticwebapp.config.json
+// DO NOT add route rules for /api/* when using external backend
+// SWA route rules only apply to SWA-managed APIs
+{
+  "routes": [
+    // NO /api/* rule here - API calls go directly to external backend
+  ]
+}
+```
+
+### 5. Post-Deployment Verification (MANDATORY)
+
+```yaml
+# MUST be in every backend deployment workflow
+- name: Verify CORS and SignalR
+  run: |
+    APP_URL="https://app-vendor-mdm-api-dev.azurewebsites.net"
+    SWA_ORIGIN="https://thankful-field-0258f8110.3.azurestaticapps.net"
+
+    # CORS preflight check
+    curl -X OPTIONS "$APP_URL/api/health" \
+      -H "Origin: $SWA_ORIGIN" \
+      -H "Access-Control-Request-Method: GET"
+
+    # SignalR negotiate check
+    curl -X POST "$APP_URL/hubs/events/negotiate?negotiateVersion=1&mockUser=Requestor" \
+      -H "Origin: $SWA_ORIGIN"
+```
+
+---
+
+## Failure Modes (Learned)
+
+### FM-1: CORS 403/blocked preflight
+**Symptom**: `Access-Control-Allow-Origin header is not present`
+**Cause**: Frontend SWA URL not in backend `GetAllowedOrigins()` for the active `ASPNETCORE_ENVIRONMENT`
+**Fix**: Add the exact SWA URL to the correct environment block in `Program.cs`
+
+### FM-2: SignalR negotiate 405
+**Symptom**: `Failed to complete negotiation with the server: Status code '405'`
+**Cause A**: `VITE_API_URL` not set, so SignalR connects to SWA origin (relative `/hubs/events`), not the backend
+**Cause B**: `ASPNETCORE_ENVIRONMENT` defaults to Production on Azure, so MockAuthMiddleware is not registered, and `[Authorize]` on EventHub rejects unauthenticated negotiate
+**Fix**: Set both `VITE_API_URL` in `.env.production` AND `ASPNETCORE_ENVIRONMENT=Development` in App Service settings
+
+### FM-3: SWA intercepting API requests
+**Symptom**: API calls return 401 before reaching the backend
+**Cause**: `staticwebapp.config.json` has `/api/*` route with `allowedRoles: ["authenticated"]`
+**Fix**: Remove `/api/*` route rules when using an external backend
+
+---
+
+## Anti-Patterns
+
+- Relying on Azure App Service default environment (it defaults to `Production`)
+- Using different env var names for the same backend URL (`VITE_API_URL` vs `VITE_API_BASE_URL`)
+- Adding SWA route rules for paths that should reach an external backend
+- Hardcoding CORS origins in only one environment block when the same SWA is used across environments
+- Deploying backend without post-deployment CORS/SignalR verification
+- Assuming a passing health check means the app works (health check doesn't test CORS or auth)
+
+---
+
+## Agent Behavior
+
+**Before Any Deployment Change**:
+1. Read this standard's Origin Registry
+2. Verify the target SWA URL exists in the backend CORS config for the matching environment
+3. Verify `.env.production` has both `VITE_API_BASE_URL` and `VITE_API_URL` pointing to the correct backend
+4. Verify `ASPNETCORE_ENVIRONMENT` is set explicitly in the workflow
+
+**When Adding a New Environment or SWA**:
+1. Update the Origin Registry table in this standard
+2. Add the new origin to `GetAllowedOrigins()` in `Program.cs`
+3. Add the new environment settings to `deploy-backend-api.yml`
+4. Create or update the corresponding `.env.[environment]` file
+
+**When Debugging Runtime Errors**:
+1. Check browser console for CORS errors → FM-1
+2. Check SignalR negotiate status code → FM-2
+3. Check if API calls return 401 before hitting backend → FM-3
+
+---
+
+## Checklist (Pre-Deploy)
+
+- [ ] Origin Registry is current
+- [ ] Backend CORS includes all SWA origins for active environment
+- [ ] `ASPNETCORE_ENVIRONMENT` is explicitly set in workflow
+- [ ] `.env.production` has both `VITE_API_BASE_URL` and `VITE_API_URL`
+- [ ] `staticwebapp.config.json` does NOT have `/api/*` route rules
+- [ ] Post-deployment CORS + SignalR verification step exists in workflow
+
+---
+
+## Reference
+
+- **Implementation**: `backend/VendorMdm.Api/Program.cs` (lines 267-321)
+- **Frontend Env**: `frontend/.env.production`
+- **SWA Config**: `frontend/staticwebapp.config.json`
+- **Deploy Workflow**: `.github/workflows/deploy-backend-api.yml`
+- **SignalR Context**: `frontend/src/context/SignalRContext.tsx`
+- **Related Standard**: [cicd-setup-standards.md](cicd-setup-standards.md)
+- **Related Standard**: [security-architecture.md](security-architecture.md)
+- **Golden Rules**: Section 5, Category 4
+- **Incident Date**: 2026-02-26 (CORS + SignalR 405 + SWA interception)

--- a/.github/workflows/deploy-backend-api.yml
+++ b/.github/workflows/deploy-backend-api.yml
@@ -73,6 +73,16 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - name: Configure App Settings (Dev)
+      uses: azure/appservice-settings@v1
+      with:
+        app-name: ${{ vars.AZURE_APP_SERVICE_NAME_DEV || 'app-vendor-mdm-api-dev' }}
+        app-settings-json: |
+          [
+            { "name": "ASPNETCORE_ENVIRONMENT", "value": "Development" },
+            { "name": "App__BaseUrl", "value": "https://thankful-field-0258f8110.3.azurestaticapps.net" }
+          ]
+
     - name: Deploy to Azure App Service (Dev)
       uses: azure/webapps-deploy@v3
       with:
@@ -93,6 +103,35 @@ jobs:
         done
         echo "Health check did not pass after 5 attempts (deployment may still be starting)"
         exit 1
+
+    - name: Verify CORS and SignalR
+      run: |
+        APP_URL="https://${{ vars.AZURE_APP_SERVICE_NAME_DEV || 'app-vendor-mdm-api-dev' }}.azurewebsites.net"
+        SWA_ORIGIN="https://thankful-field-0258f8110.3.azurestaticapps.net"
+        echo "=== CORS Preflight Check ==="
+        CORS_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+          -X OPTIONS "$APP_URL/api/health" \
+          -H "Origin: $SWA_ORIGIN" \
+          -H "Access-Control-Request-Method: GET" \
+          -H "Access-Control-Request-Headers: Content-Type")
+        echo "CORS preflight status: $CORS_RESPONSE"
+        if [ "$CORS_RESPONSE" -ne 204 ] && [ "$CORS_RESPONSE" -ne 200 ]; then
+          echo "WARNING: CORS preflight returned $CORS_RESPONSE (expected 200/204)"
+        fi
+        echo "=== CORS Headers Check ==="
+        curl -s -I "$APP_URL/api/health" \
+          -H "Origin: $SWA_ORIGIN" | grep -i "access-control" || echo "WARNING: No CORS headers in response"
+        echo "=== SignalR Negotiate Check ==="
+        SIGNALR_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+          -X POST "$APP_URL/hubs/events/negotiate?negotiateVersion=1&mockUser=Requestor" \
+          -H "Origin: $SWA_ORIGIN" \
+          -H "Content-Type: application/json")
+        echo "SignalR negotiate status: $SIGNALR_STATUS"
+        if [ "$SIGNALR_STATUS" -eq 405 ]; then
+          echo "ERROR: SignalR negotiate returned 405 - check ASPNETCORE_ENVIRONMENT and MockAuth"
+          exit 1
+        fi
+        echo "Post-deployment verification complete"
 
   deploy-prod:
     needs: build

--- a/backend/VendorMdm.Api/Program.cs
+++ b/backend/VendorMdm.Api/Program.cs
@@ -283,6 +283,7 @@ string[] GetAllowedOrigins(IConfiguration config, IWebHostEnvironment env)
         return new[]
         {
             baseUrl ?? "https://purple-moss-066604e03.4.azurestaticapps.net",
+            "https://thankful-field-0258f8110.3.azurestaticapps.net",
             "http://localhost:3000",
             "http://localhost:5173"
         };
@@ -298,6 +299,7 @@ string[] GetAllowedOrigins(IConfiguration config, IWebHostEnvironment env)
             "http://localhost:3003",
             "http://localhost:5173",
             "http://localhost:5174",
+            "https://thankful-field-0258f8110.3.azurestaticapps.net",
             "https://victorious-water-095da360f.5.azurestaticapps.net",
             "https://purple-moss-066604e03.4.azurestaticapps.net",
             "https://stvendormdmdev.blob.core.windows.net"

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=https://app-vendor-mdm-api-dev.azurewebsites.net/api
+VITE_API_URL=https://app-vendor-mdm-api-dev.azurewebsites.net

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5001';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || 'http://localhost:5001';
 
 // Create axios instance with interceptors
 const apiClient = axios.create({

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -1,12 +1,6 @@
 {
   "routes": [
     {
-      "route": "/api/*",
-      "allowedRoles": [
-        "authenticated"
-      ]
-    },
-    {
       "route": "/admin/*",
       "allowedRoles": [
         "admin"


### PR DESCRIPTION
## Summary
- Fix CORS: add SWA origin (`thankful-field-*`) to backend allowed origins
- Fix SignalR 405: add `VITE_API_URL` to `.env.production` + set `ASPNETCORE_ENVIRONMENT=Development` in deploy workflow
- Fix SWA: remove `/api/*` route rule that intercepted external API calls
- Add post-deployment CORS + SignalR verification step to CI
- New standard: `deployment-environment-standard.md` (#35)

## Test plan
- [ ] Backend deploys with `ASPNETCORE_ENVIRONMENT=Development`
- [ ] CORS preflight passes from SWA origin
- [ ] SignalR negotiate returns 200 (not 405)
- [ ] API calls from frontend reach backend without CORS block
- [ ] Post-deployment verification step passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)