### PR TITLE
fix(ci): start App Service before deploy (Site Disabled 403)

### DIFF
--- a/.agent/rules/standards/deployment-environment-standard.md
+++ b/.agent/rules/standards/deployment-environment-standard.md
@@ -131,6 +131,11 @@ VITE_API_URL=https://app-vendor-mdm-api-dev.azurewebsites.net              # Wit
 **Cause**: `staticwebapp.config.json` has `/api/*` route with `allowedRoles: ["authenticated"]`
 **Fix**: Remove `/api/*` route rules when using an external backend
 
+### FM-4: App Service Disabled / Site Disabled (403)
+**Symptom**: `Deployment Failed, Error: Site Disabled (CODE: 403)`
+**Cause**: Azure App Service is stopped/disabled (cost management, manual stop, or Azure auto-stop on free/dev tiers)
+**Fix**: Workflow MUST check App Service state and start it before deploying. Use `az webapp show --query "state"` and `az webapp start` if not Running.
+
 ---
 
 ## Anti-Patterns
@@ -141,6 +146,7 @@ VITE_API_URL=https://app-vendor-mdm-api-dev.azurewebsites.net              # Wit
 - Hardcoding CORS origins in only one environment block when the same SWA is used across environments
 - Deploying backend without post-deployment CORS/SignalR verification
 - Assuming a passing health check means the app works (health check doesn't test CORS or auth)
+- Deploying to an App Service without first checking if it is running
 
 ---
 

--- a/.github/workflows/deploy-backend-api.yml
+++ b/.github/workflows/deploy-backend-api.yml
@@ -73,6 +73,20 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - name: Ensure App Service is running (Dev)
+      run: |
+        APP_NAME="${{ vars.AZURE_APP_SERVICE_NAME_DEV || 'app-vendor-mdm-api-dev' }}"
+        RG="${{ vars.AZURE_RESOURCE_GROUP_DEV || 'rg-vendor-mdm-dev-v3' }}"
+        echo "Checking App Service state..."
+        STATE=$(az webapp show --name "$APP_NAME" --resource-group "$RG" --query "state" -o tsv 2>/dev/null || echo "Unknown")
+        echo "App Service state: $STATE"
+        if [ "$STATE" != "Running" ]; then
+          echo "Starting App Service..."
+          az webapp start --name "$APP_NAME" --resource-group "$RG"
+          echo "Waiting for App Service to start..."
+          sleep 15
+        fi
+
     - name: Configure App Settings (Dev)
       uses: azure/appservice-settings@v1
       with:
@@ -152,6 +166,20 @@ jobs:
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Ensure App Service is running (Prod)
+      run: |
+        APP_NAME="${{ vars.AZURE_APP_SERVICE_NAME_PROD || 'app-vendor-mdm-api-prod' }}"
+        RG="${{ vars.AZURE_RESOURCE_GROUP_PROD || 'rg-vendor-mdm-prod' }}"
+        echo "Checking App Service state..."
+        STATE=$(az webapp show --name "$APP_NAME" --resource-group "$RG" --query "state" -o tsv 2>/dev/null || echo "Unknown")
+        echo "App Service state: $STATE"
+        if [ "$STATE" != "Running" ]; then
+          echo "Starting App Service..."
+          az webapp start --name "$APP_NAME" --resource-group "$RG"
+          echo "Waiting for App Service to start..."
+          sleep 15
+        fi
 
     - name: Deploy to Azure App Service (Prod)
       uses: azure/webapps-deploy@v3


### PR DESCRIPTION
## Summary
- Add `az webapp start` pre-deploy step to both dev and prod deployments
- Prevents `Site Disabled (CODE: 403)` deployment failures
- Documents FM-4 in deployment-environment-standard

## Test plan
- [ ] Backend deploy workflow starts stopped App Service before deploying
- [ ] Health check passes after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)